### PR TITLE
Fix init.sh script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,7 @@
 # Use this script by running ./init.sh your_app_name
 # More details at https://www.codewithjason.com/instant-rails/
 
-function fill_template {
+fill_template () {
   sed -ie "s/\${app_name}/$APP_NAME/" $1
 }
 
@@ -19,12 +19,12 @@ fill_template init.sql
 
 cp -R ../template template
 
-docker compose run -e INSTANT_RAILS_APP_NAME=$1 web \
+docker-compose run -e INSTANT_RAILS_APP_NAME=$1 web \
   rails new . \
   -f \
   -T \
   -d postgresql \
   -m template/template.rb
 
-docker compose run web bin/initialize
-docker compose up
+docker-compose run web bin/initialize
+docker-compose up


### PR DESCRIPTION
* `docker-compose` is written with a dash "-"
* `function fill_template` will error out on non-bash systems. The POSIX
syntax is universal

Reference: https://stackoverflow.com/questions/12468889/bash-script-error-function-not-found-why-would-this-appear